### PR TITLE
Abort pending requests on reconnect

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ module.exports = function(/* environment */) {
         path: '/favicon.ico',
         delay: 5000,
         multiplier: 1.5,
-        timeout: 30000,
+        timeout: 15000,
         maxDelay: 60000,
         maxTimes: -1
       }

--- a/addon/constants.js
+++ b/addon/constants.js
@@ -11,7 +11,7 @@ export const CONFIG = {
 		path: '/favicon.ico',
 		delay: 5000,
 		multiplier: 1.5,
-		timeout: 30000,
+		timeout: 15000,
 		maxDelay: 60000,
 		maxTimes: -1
 	}

--- a/addon/services/network.js
+++ b/addon/services/network.js
@@ -2,7 +2,7 @@ import { computed, getWithDefault, observer } from '@ember/object';
 import Evented from '@ember/object/evented';
 import Service from '@ember/service';
 import { STATES, CONFIG } from '../constants';
-import fetch from 'fetch';
+import fetch, { AbortController } from 'fetch';
 import { cancel, later } from '@ember/runloop';
 import { getOwner } from '@ember/application';
 import {

--- a/addon/services/network.js
+++ b/addon/services/network.js
@@ -283,7 +283,7 @@ export default Service.extend(Evented, {
 		let status = 0;
 
 		try {
-			const response = await fetch(reconnect.path, { method: 'HEAD', cache: 'no-store', signal });
+			const response = await fetch(reconnect.path, { method: 'HEAD', cache: 'no-store', signal, headers: { 'cache-control': 'no-cache' } });
 
 			this.get('_controllers').removeObject(controller);
 

--- a/addon/services/network.js
+++ b/addon/services/network.js
@@ -277,13 +277,17 @@ export default Service.extend(Evented, {
 		// Push new controller.
 		this.get('_controllers').pushObject(controller);
 
-		const { signal } = controller;
 		const timeout = later(controller, 'abort', reconnect.timeout);
 		const start = performance.now();
 		let status = 0;
 
 		try {
-			const response = await fetch(reconnect.path, { method: 'HEAD', cache: 'no-store', signal, headers: { 'cache-control': 'no-cache' } });
+			const response = await fetch(reconnect.path, {
+				method: 'HEAD',
+				cache: 'no-store',
+				signal: controller.signal,
+				headers: { 'cache-control': 'no-cache' }
+			});
 
 			this.get('_controllers').removeObject(controller);
 
@@ -298,6 +302,10 @@ export default Service.extend(Evented, {
 			}
 		} finally {
 			cancel(timeout);
+
+			if (this.isDestroyed) {
+				return;
+			}
 
 			if (!this.get('isReconnecting')) {
 				this.setProperties({

--- a/tests/unit/services/network-test.js
+++ b/tests/unit/services/network-test.js
@@ -285,6 +285,24 @@ test('it tests online connection on network change', async function(assert) {
 	assert.equal(this.sandbox.server.requestCount, 2, 'requests are expected');
 });
 
+test('it tests online connection with no cache', async function(assert) {
+	this.goOnline();
+
+	const service = this.subject();
+
+	await waitForIdle();
+
+	this.goOnline();
+
+	await waitForIdle();
+
+	assert.equal(service.get('state'), STATES.ONLINE, 'state is expected');
+
+	this.sandbox.server.requests.forEach((request) => {
+		assert.equal(request.requestHeaders['cache-control'], 'no-cache', 'header is expected');
+	});
+});
+
 test('it supports no implementations of connection API', async function(assert) {
 	this.goOnline();
 

--- a/tests/unit/services/network-test.js
+++ b/tests/unit/services/network-test.js
@@ -676,6 +676,36 @@ test('it never returns negative remaining', async function(assert) {
 	this.sandbox.clock.tick(5);
 });
 
+test('it resets reconnects on network change', async function(assert) {
+	this.goLimited();
+
+	this.config.reconnect = {
+		auto: true,
+		delay: 5000,
+		multiplier: 2,
+		maxDelay: 60000,
+		maxTimes: 2
+	};
+
+	const service = this.subject();
+
+	await wait(forSettledWaiters);
+
+	await this.tick(2);
+
+	assert.equal(service.get('state'), STATES.LIMITED, 'state is expected');
+	assert.equal(this.sandbox.server.requestCount, 1, 'requests are expected');
+
+	this.goLimited();
+
+	await wait(forSettledWaiters);
+
+	await this.tick(5);
+
+	assert.equal(service.get('state'), STATES.LIMITED, 'state is expected');
+	assert.equal(this.sandbox.server.requestCount, 3, 'requests are expected');
+});
+
 // config
 
 test('it allows path config', async function(assert) {

--- a/tests/unit/services/network-test.js
+++ b/tests/unit/services/network-test.js
@@ -679,6 +679,9 @@ test('it never returns negative remaining', async function(assert) {
 test('it resets reconnects on network change', async function(assert) {
 	this.goLimited();
 
+	this.sandbox.server.respondImmediately = false;
+	this.sandbox.server.autoRespond = true;
+	this.sandbox.server.autoRespondAfter = 10;
 	this.config.reconnect = {
 		auto: true,
 		delay: 5000,
@@ -689,6 +692,8 @@ test('it resets reconnects on network change', async function(assert) {
 
 	const service = this.subject();
 
+	this.sandbox.clock.tick(10);
+
 	await wait(forSettledWaiters);
 
 	await this.tick(2);
@@ -698,7 +703,11 @@ test('it resets reconnects on network change', async function(assert) {
 
 	this.goLimited();
 
+	this.sandbox.clock.tick(10);
+
 	await wait(forSettledWaiters);
+
+	this.sandbox.clock.tick(10);
 
 	await this.tick(5);
 

--- a/tests/unit/services/network-test.js
+++ b/tests/unit/services/network-test.js
@@ -793,7 +793,7 @@ test('it abort reconnect on timeout', async function(assert) {
 
 	this.sandbox.clock.tick(10000);
 
-	await waitForIdle();
+	await this.tick(1);
 
 	assert.equal(service.get('state'), STATES.LIMITED, 'state is expected');
 });


### PR DESCRIPTION
- Abort all concurrent requests on reconnect.
- Add no-cache header to reconnect requests.
- Prevent exceptions on service destroy.