### PR TITLE
Allow to specify the mode on the fetch request

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ module.exports = function (/* environment */) {
         timeout: 15000,
         maxDelay: 60000,
         maxTimes: -1,
+        mode: null,
       },
     },
   };
@@ -112,6 +113,7 @@ Posible values:
   - `timeout`: Reconnect request timeout.
   - `maxDelay`: Maximum delay for a reconnect. Default: `60000`.
   - `maxTimes`: Maximum times for a reconnect. When value is negative, its `Infinity`. Default: `-1`.
+  - `mode`: Helpful if you want to set the mode to something other than default like `no-cors`. Default: `null`.
 
 ## Contribute
 

--- a/addon/constants.js
+++ b/addon/constants.js
@@ -14,6 +14,7 @@ export const CONFIG = {
     timeout: 15000,
     maxDelay: 60000,
     maxTimes: -1,
+    mode: null,
   },
 };
 

--- a/addon/services/network.js
+++ b/addon/services/network.js
@@ -7,6 +7,7 @@ import { getOwner } from '@ember/application';
 import { equal, notEmpty, readOnly } from '@ember/object/computed';
 import { A } from '@ember/array';
 import { tracked } from '@glimmer/tracking';
+import { isPresent } from '@ember/utils';
 
 export default class NetworkService extends Service.extend(Evented) {
 	@tracked lastReconnectDuration = 0;
@@ -143,12 +144,18 @@ export default class NetworkService extends Service.extend(Evented) {
 		let status = 0;
 
 		try {
-			const response = await this._fetch(reconnect.path, {
+			let requestOptions = {
 				method: 'HEAD',
 				cache: 'no-store',
 				signal: controller.signal,
 				headers: { 'cache-control': 'no-cache' }
-			});
+			}
+
+			if (isPresent(reconnect.mode)) {
+				requestOptions.mode = reconnect.mode;
+			}
+
+			const response = await this._fetch(reconnect.path, requestOptions);
 
 			if (!this.isDestroyed) {
 				this._controllers.removeObject(controller);


### PR DESCRIPTION
Is helpful if one wants to set the mode to `no-cors` like I had to as per my requirement.